### PR TITLE
Convert RGB values to float and back.

### DIFF
--- a/lib/color/rgb.rb
+++ b/lib/color/rgb.rb
@@ -17,6 +17,13 @@ module Color
       self.new(red, green, blue)
     end
 
+    def self.from_float(f_array)
+      red = (f_array[0] * 255).ceil
+      green = (f_array[1] * 255).ceil
+      blue = (f_array[2] * 255).ceil
+      self.new(red, green, blue)
+    end
+
     def initialize(r, g, b)
       @r = r.to_f
       @g = g.to_f
@@ -32,6 +39,10 @@ module Color
 
     def to_xyz
       Color::XYZ.from_rgb(self).to_a
+    end
+
+    def to_f
+      [(@r / 255.0), (@g / 255.0), (@b / 255.0)]
     end
 
     def to_int

--- a/spec/color/rgb_spec.rb
+++ b/spec/color/rgb_spec.rb
@@ -16,6 +16,28 @@ describe Color::RGB do
     end
   end
 
+  context 'converting to and from floats' do
+    let(:rgb) { [34, 155, 167] }
+    let(:color) { Color::RGB.from_array(rgb) }
+    let(:floated) { [0.1333, 0.6078, 0.6549] }
+
+    describe '.to_f' do
+      it 'should convert rgb to float' do
+        expect(color.to_f).to eq([
+            0.13333333333333333,
+            0.6078431372549019,
+            0.6549019607843137
+          ])
+      end
+    end
+
+    describe '.from_f' do
+      it 'should convert float to rgb and return an array' do
+        expect(Color::RGB.from_float(floated).to_a).to eq(rgb)
+      end
+    end
+  end
+
   context 'packing to integers' do
     let(:rgb)   { [255, 20, 147] }
     let(:color) { Color::RGB.from_array(rgb) }


### PR DESCRIPTION
I was working on [SOMs](http://davis.wpi.edu/~matt/courses/soms/) and it's helpful to work with RGB as floats. Found your lib while looking for Ruby RGB conversion libs and figured I could add it and share it. 
