### PR TITLE
 small refactor for conciseness

### DIFF
--- a/lib/color/cie_lab.rb
+++ b/lib/color/cie_lab.rb
@@ -4,7 +4,7 @@ module Color
     attr_reader :x, :y, :z
 
     def self.from_xyz(xyz_color)
-      self.new(xyz_color)
+      new(xyz_color)
     end
 
     def initialize(color)

--- a/lib/color/comparison.rb
+++ b/lib/color/comparison.rb
@@ -3,7 +3,7 @@ module Color
     attr_reader :rgb_color
 
     def self.distance(rgb, rgb_match)
-      color_comparitor = self.new(rgb)
+      color_comparitor = new(rgb)
       color_comparitor.compare(rgb_match)
     end
 

--- a/lib/color/rgb.rb
+++ b/lib/color/rgb.rb
@@ -7,14 +7,14 @@ module Color
       if rgb_array.length != 3
         raise RGBArraySizeError.new("RGB array should contain 3 values")
       end
-      self.new(rgb_array[0], rgb_array[1], rgb_array[2])
+      new(rgb_array[0], rgb_array[1], rgb_array[2])
     end
 
     def self.from_int(rgb_int)
       red   = (rgb_int >> 16) & 0xFF;
       green = (rgb_int >> 8) & 0xFF;
       blue  = rgb_int & 0xFF;
-      self.new(red, green, blue)
+      new(red, green, blue)
     end
 
     def initialize(r, g, b)

--- a/lib/color/xyz.rb
+++ b/lib/color/xyz.rb
@@ -4,7 +4,7 @@ module Color
     attr_reader :r, :g, :b
 
     def self.from_rgb(rgb_color)
-      self.new(rgb_color)
+      new(rgb_color)
     end
 
     def initialize(color)


### PR DESCRIPTION
this pull request removes the 'self' in calls within a Class for a new instance of that class.  
self.new is redundant when already in the scope of self.
All specs passing.
